### PR TITLE
[feature] add option for creating lib-virt network with a single vlan…

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ kvm_virtual_networks: []
   #   bridge_name: 'vmbr101'
   #   autostart: true
   #   state: active
+  # - name: 'maas'
+  #   mode: 'bridge'
+  #   bridge_name: 'ovsbr0'
+  #   autostart: true
+  #   state: active
+  #   virtualport_type: 'openvswitch'
+  #   vlan: 193
 
 # Define VM(s) to create
 kvm_vms: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -214,6 +214,13 @@ kvm_virtual_networks: []
   #   bridge_name: 'vmbr101'
   #   autostart: true
   #   state: active
+  # - name: 'maas'
+  #   mode: 'bridge'
+  #   bridge_name: 'ovsbr0'
+  #   autostart: true
+  #   state: active
+  #   virtualport_type: 'openvswitch'
+  #   vlan: 193
 
 # Define VM(s) to create
 kvm_vms: []

--- a/templates/vm-network.xml.j2
+++ b/templates/vm-network.xml.j2
@@ -49,4 +49,9 @@
    </portgroup>
 {%   endfor %}
 {% endif %}
+{% if item['vlan'] is defined %}
+  <vlan>
+    <tag id="{{ item['vlan'] }}" />
+  </vlan>
+{% endif %}
 </network>


### PR DESCRIPTION
… tag.

Update jinja template to allow creation of a lib-virt network that when 
used by a kvm guest would add the guests vnic as an access port in a 
specific vlan in openvswitch. Some lib-virt integrations such as MAAS do 
not support adding a vnic to a specific 'portgroup'.

fixes #18