### PR TITLE
added service task to ensure that service starts after config

### DIFF
--- a/tasks/config_kvm.yml
+++ b/tasks/config_kvm.yml
@@ -53,3 +53,9 @@
         kvm_enable_tcp and
         ansible_os_family == "Debian" and
         not ansible_check_mode
+
+- name: config_kvm | starting libvirt service 
+  service: 
+    name: "{{ kvm_service_name }}"
+    state: started
+    enabled: yes


### PR DESCRIPTION
I noticed that the libvirtd did not start after the config file is applied - the handle doesn't do anything.