### PR TITLE
Update CI and meta for Ubuntu 20.04 Focal Fossa support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   global:
     - ROLE_NAME: kvm
   matrix:
+    - MOLECULE_DISTRO_BOX: generic/ubuntu2004
     - MOLECULE_DISTRO_BOX: generic/ubuntu1804
     - MOLECULE_DISTRO_BOX: debian/buster64
     - MOLECULE_DISTRO_BOX: debian/stretch64

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,8 +12,9 @@ galaxy_info:
         - 7
     - name: Ubuntu
       versions:
-        - bionic
+        - focal
         - cosmic
+        - bionic
         - trusty
         - xenial
         - yakkety


### PR DESCRIPTION
Update support to include Ubuntu 20.04 Focal Fossa.