### PR TITLE
Fix depricated Jinja test used as filter.

### DIFF
--- a/tasks/config_vms.yml
+++ b/tasks/config_vms.yml
@@ -69,7 +69,7 @@
     command: info
   when:
     - item['host'] is not defined
-    - ansible_version.full | version_compare('2.3', '>=')
+    - ansible_version.full is version('2.5', '>=')
   loop: "{{ kvm_vms }}"
 
 - name: config_vms | Setting autostart status
@@ -81,5 +81,5 @@
   when:
     - item['host'] is defined
     - inventory_hostname == item['host']
-    - ansible_version.full | version_compare('2.3', '>=')
+    - ansible_version.full is version('2.5', '>=')
   loop: "{{ kvm_vms }}"


### PR DESCRIPTION
Using jinja tests as filters was removed in Ansible 2.9.
In 2.5 version_compare was renamed to version