### PR TITLE
Update install_packages_redhat.yml

### DIFF
--- a/tasks/install_packages_redhat.yml
+++ b/tasks/install_packages_redhat.yml
@@ -23,9 +23,9 @@
   until: result is successful
   when: >
     (ansible_distribution == "CentOS" and
-    ansible_distribution_major_version = '8') or
+    ansible_distribution_major_version == '8') or
     (ansible_distribution == "RedHat" and
-    ansible_distribution_major_version = '8')
+    ansible_distribution_major_version == '8')
   
 
 - name: redhat | Creating libvirt Group


### PR DESCRIPTION
Adds missing '=' to when statement

## Description
The when statement in line 24 is missing two '=' to handle the condition properly. This patch adds the missing '='.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
