### PR TITLE
Add mac address to interface on VM creation

### DIFF
--- a/templates/vm-template.xml.j2
+++ b/templates/vm-template.xml.j2
@@ -42,7 +42,7 @@
 {% for int in item['network_interfaces'] %}
     <interface type='{{ int['type'] }}'>
 {%   if int['mac'] is defined %}
-      <mac address='{{ int['mac']}}'/>
+      <mac address='{{ int['mac'] }}'/>
 {%   endif %}
 {%   if int['portgroup'] is not defined %}
       <source {{ int['type'] }}='{{ int['source'] }}'/>

--- a/templates/vm-template.xml.j2
+++ b/templates/vm-template.xml.j2
@@ -41,6 +41,9 @@
 {% endfor %}
 {% for int in item['network_interfaces'] %}
     <interface type='{{ int['type'] }}'>
+{%   if int['mac'] is defined %}
+      <mac address='{{ int['mac']}}'/>
+{%   endif %}
 {%   if int['portgroup'] is not defined %}
       <source {{ int['type'] }}='{{ int['source'] }}'/>
 {%   elif int['portgroup'] is defined %}


### PR DESCRIPTION
This PR allows to define the MAC address of an interface.

## Description

The change allows to optionally specify the MAC address of an interface, in those scenarios where the MAC address of the interface can be later used and needs to be known in advance.

## Related Issue
https://github.com/mrlesmithjr/ansible-kvm/issues/41

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
