### PR TITLE
Add Ansible Galaxy publishing workflow

### DIFF
--- a/.github/workflows/release-galaxy.yml
+++ b/.github/workflows/release-galaxy.yml
@@ -1,0 +1,29 @@
+---
+name: Ansible Galaxy
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  galaxy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Ansible
+        run: pip install ansible-core
+
+      - name: Trigger Galaxy import
+        run: >-
+          ansible-galaxy role import
+          --api-key ${{ secrets.GALAXY_API_KEY }}
+          ${{ github.repository_owner }}
+          ${{ github.event.repository.name }}


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically publish releases to Ansible Galaxy
- Triggers only on GitHub release publish events (not on every push)
- Uses current action versions to avoid deprecation warnings

## Changes

- Create `.github/workflows/release-galaxy.yml` with:
  - `actions/checkout@v4` (updated from v3)
  - `actions/setup-python@v5` (updated from v4)
  - Python 3.11
  - Minimal dependencies (ansible-core only, no caching needed)
  - Simplified workflow without unnecessary matrix strategy

## Configuration Required

Before this workflow can run successfully, you need to:

1. Get a Galaxy API token from https://galaxy.ansible.com/ui/token/
2. Add it as a repository secret:
   - Go to Settings > Secrets and variables > Actions
   - Click "New repository secret"
   - Name: `GALAXY_API_KEY`
   - Value: Your token from step 1

## Testing

This workflow will trigger automatically when a new GitHub release is published.

## Benefits

- Eliminates deprecated `actions/cache@v2` warnings
- Uses latest stable action versions
- Simpler, faster workflow (no unnecessary dependencies)
- Only publishes on actual releases (not every commit)